### PR TITLE
IT-35456 / Privileges to extract ZIPs for apg_install

### DIFF
--- a/apg-install-rpm/build.gradle
+++ b/apg-install-rpm/build.gradle
@@ -9,7 +9,7 @@ apply plugin: 'maven-publish'
 
 ospackage {
 	packageName = 'apg-install-rpm'
-	version = '1.3'
+	version = '1.4'
 	release = 1
 	os = LINUX
 	type = BINARY

--- a/apg-install-rpm/packaging/rpm/pre-install.sh
+++ b/apg-install-rpm/packaging/rpm/pre-install.sh
@@ -49,3 +49,6 @@ echo "Adding Sudoers Rights for Digiflex Installations"
 echo "$userAndGroupName ALL= (root) NOPASSWD: $( which rpm ) -Uvh downloads/apg-digiflex-jadas-*" >> /etc/sudoers.d/$userAndGroupName
 echo "$userAndGroupName ALL= (root) NOPASSWD: $( which rpm ) -Uvh downloads/apg-digiflex-web-it21*" >> /etc/sudoers.d/$userAndGroupName
 echo "$userAndGroupName ALL= (root) NOPASSWD: $( which rpm ) -Uvh downloads/apg-digiflex-web-sa*" >> /etc/sudoers.d/$userAndGroupName
+
+echo "Adding Sudoers Rights for GUI(s) Installations, it might become more restrictive"
+echo "$userAndGroupName ALL= (root) NOPASSWD: $( which unzip) *.zip" >> /etc/sudoers.d/$userAndGroupName


### PR DESCRIPTION
Hallo @apgsga-uge ,
Ich werde diesen PullRequest sofort mergen, hoffe dass es für dir in Ordnung ist, sonst können wir es den Installer später anpassen.
Momentan wird den Version 1.4 nur auf jenkins-t installiert um IT-35456 zu testen (darum merge ich sofort, damit ich testen kann)
Sehr wahrscheinlich wird es möglich in Zukunft den Rechte auf ZIPs zu beschrenken für gewissen File Namen.